### PR TITLE
feat: Add optional date argument and enhance spending comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,38 @@ It’s typically recommended to use virtual environments when working with speci
 All dependencies will be installed for the project; proceed.
 
 #### Running the code
-You can run the code using;
+You can run the code using:
+```bash
+python comparison.py
 ```
-$ python comparison.py
+
+The script also accepts an optional date argument to specify the reference date for the comparison. If omitted, it defaults to the current date.
+
+*   `--date` or `-d`: Specify a date in YYYY-MM-DD format.
+
+Example:
+```bash
+python comparison.py --date 2023-11-15
 ```
+
+This will generate a comparison as of November 15, 2023, comparing spending up to that day against the equivalent period in October 2023.
+
+## How it Works
+The script fetches your transactions for two periods:
+1.  The "current" period: This starts from the first day of the month of the reference date (either the date provided via `--date` or today's date if no argument is given) and includes all transactions up to and including the reference date.
+2.  The "previous" period: This covers the entire month immediately preceding the reference date's month.
+
+It then calculates cumulative spending for both periods and plots them. The comparison text ("X more/less than last month") is determined by comparing the total spending up to the reference day in the "current" period against a proportionally equivalent day in the "previous" period.
+
 ## Result
-The final graph looks like this -- not pretty but has all the information needed.
+The final graph provides a visual comparison of cumulative spending. An example is shown below (note: your specific output will vary).
+
 <img width="500" alt="2024-03-06-cumulative_spending_comparison" src="https://github.com/micklynch/lunchmoney/assets/37063953/02f7fe2b-f09f-403d-bd03-bc4f77a33f44">
 
-* [ ] Need to align the days of the month better, currently the x-axis are the dates from the previous month. This causes slight visualization issue when months have different dates (e.g. Feb & Mar)
+**Note on the plot:**
+*   The solid green line shows your spending in the current reference month up to the specified (or current) date.
+*   The dashed blue line shows your spending throughout the entire previous month.
+*   A dotted green line may also appear, showing "Projected Spending" for the remainder of the current reference month. This projection is based on transactions already made within that month that occur after the reference date.
+
+**Potential Improvements:**
+* [ ] Further refinement of x-axis alignment and labeling for clarity, especially when comparing months of different lengths.

--- a/comparison.py
+++ b/comparison.py
@@ -5,6 +5,7 @@ import math
 import pandas as pd
 import matplotlib.pyplot as plt
 import sys
+import argparse
 
 # Load the .env file
 load_dotenv()
@@ -18,130 +19,265 @@ headers = {
     "Authorization": f"Bearer {lm_api}"
 }
 
-# using pandas, get the date of the start of the month and then the date of the previous month
-today = pd.to_datetime('today')
-start_of_this_month = today.replace(day=1)
-end_of_previous_month = start_of_this_month - pd.Timedelta(days=1)
-start_of_previous_month = end_of_previous_month.replace(day=1)
+# Create an ArgumentParser object
+parser = argparse.ArgumentParser(description="Compare spending with the previous month.")
+# Add an optional argument --date (or -d) that accepts a string
+parser.add_argument("--date", "-d", type=str, help="Specify a date in YYYY-MM-DD format.")
+# Parse the arguments
+args = parser.parse_args()
 
-url = f"{lm_hostname}/v1/transactions"
+# Process the date argument
+if args.date:
+    try:
+        input_date = pd.to_datetime(args.date)
+    except ValueError:
+        print("Error: Invalid date format. Please use YYYY-MM-DD.")
+        sys.exit(1)
+else:
+    input_date = pd.to_datetime('today')
+
+def calculate_date_boundaries(current_date: pd.Timestamp) -> tuple[pd.Timestamp, pd.Timestamp, pd.Timestamp]:
+    """
+    Calculates key date boundaries based on the provided current_date.
+
+    Args:
+        current_date: The reference date (pandas Timestamp).
+
+    Returns:
+        A tuple containing:
+            - start_of_this_month (pandas Timestamp)
+            - end_of_previous_month (pandas Timestamp)
+            - start_of_previous_month (pandas Timestamp)
+    """
+    start_of_this_month = current_date.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    end_of_previous_month = start_of_this_month - pd.Timedelta(days=1)
+    start_of_previous_month = end_of_previous_month.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    return start_of_this_month, end_of_previous_month, start_of_previous_month
+
+# Calculate key date boundaries using the new function
+start_of_this_month, end_of_previous_month, start_of_previous_month = calculate_date_boundaries(input_date)
+
+# Define API URL
+api_url = f"{lm_hostname}/v1/transactions"
+
+def get_transactions_df(start_date_str: str, end_date_str: str, hostname: str, request_headers: dict) -> pd.DataFrame:
+    """
+    Fetches transactions from the API for a given date range and processes them into a DataFrame.
+
+    Args:
+        start_date_str: The start date for transactions (YYYY-MM-DD).
+        end_date_str: The end date for transactions (YYYY-MM-DD).
+        hostname: The base URL of the API.
+        request_headers: Headers to include in the API request.
+
+    Returns:
+        A pandas DataFrame containing the processed transaction data.
+        Exits the script if no transactions are found or if there's an API error.
+    """
+    params = {
+        "start_date": start_date_str,
+        "end_date": end_date_str
+    }
+    response = requests.get(f"{hostname}/v1/transactions", headers=request_headers, params=params)
+    response.raise_for_status() # Raises an exception for HTTP errors (4xx or 5xx)
+
+    transactions_data = response.json().get('transactions')
+    if not transactions_data: # Checks for None or empty list
+        print(f"No transaction data found between {start_date_str} and {end_date_str}.")
+        # Depending on requirements, might return empty DF instead of exiting:
+        # return pd.DataFrame()
+        sys.exit()
+
+    df = pd.DataFrame(transactions_data)
+
+    # Format the date, amount, and other flags
+    df['date'] = pd.to_datetime(df['date'], format='%Y-%m-%d')
+    df['amount'] = df['amount'].astype(float)
+    df['exclude_from_totals'] = df['exclude_from_totals'].astype(bool)
+    df['is_income'] = df['is_income'].astype(bool)
+
+    # Remove items that are income or flagged to remove from totals
+    df = df[(df["exclude_from_totals"] == False) & (df['is_income'] == False)]
+    return df
 
 ###
 # Get this month's transactions
 ###
-params = {
-    "start_date": start_of_this_month.strftime('%Y-%m-%d'),
-    "end_date": (today  + pd.Timedelta(days=1)).strftime('%Y-%m-%d') # Grab one day into the future to avoid issues with 1st of the month
-}
-response = requests.get(url, headers=headers, params=params)
-# get all the transactions for this past month and add to dataframe
-transactions = response.json().get('transactions')
-if transactions is None:
-    print("No data this month")
-    sys.exit()
-
-current_month_df = pd.DataFrame(transactions)
-
-# format the date, amount and other flags
-current_month_df['date'] = pd.to_datetime(current_month_df['date'], format='%Y-%m-%d')
-current_month_df['amount']=current_month_df['amount'].astype(float)
-current_month_df['exclude_from_totals']=current_month_df['exclude_from_totals'].astype(bool)
-current_month_df['is_income']=current_month_df['is_income'].astype(bool)
-
-# remove items that are income or flagged to remove from totals
-current_month_df = current_month_df[(current_month_df["exclude_from_totals"] == False) & (current_month_df['is_income']== False)]
+current_month_start_str = start_of_this_month.strftime('%Y-%m-%d')
+current_month_end_str = (input_date + pd.Timedelta(days=1)).strftime('%Y-%m-%d') # Includes all of input_date
+current_month_df = get_transactions_df(current_month_start_str, current_month_end_str, lm_hostname, headers)
 
 ###
 # Get last month's transactions
 ###
-params = {
-    "start_date": start_of_previous_month.strftime('%Y-%m-%d'),
-    "end_date": end_of_previous_month.strftime('%Y-%m-%d')
-}
+previous_month_start_str = start_of_previous_month.strftime('%Y-%m-%d')
+previous_month_end_str = end_of_previous_month.strftime('%Y-%m-%d')
+last_month_df = get_transactions_df(previous_month_start_str, previous_month_end_str, lm_hostname, headers)
 
-response = requests.get(url, headers=headers, params=params)
 
-# Do the same again for last month's transactions
-transactions = response.json().get('transactions')
-if transactions is None:
-    print("No data last month")
-    sys.exit()
-last_month_df = pd.DataFrame(transactions)
+# --- Prepare data for "future" spending line (all transactions in current month) ---
+end_of_current_month_for_plot = input_date.replace(day=1) + pd.offsets.MonthEnd(0)
+full_current_month_df = pd.DataFrame() # Initialize as empty
+# Only fetch if the end_of_current_month_for_plot is actually after input_date's effective range for current_month_df
+if end_of_current_month_for_plot.strftime('%Y-%m-%d') >= current_month_end_str: # Compare string dates
+    # Fetch all transactions from the start of the month to the actual end of the month
+    full_current_month_df = get_transactions_df(
+        current_month_start_str, # already defined: start_of_this_month.strftime('%Y-%m-%d')
+        (end_of_current_month_for_plot + pd.Timedelta(days=1)).strftime('%Y-%m-%d'), # include last day
+        lm_hostname,
+        headers
+    )
 
-last_month_df['date'] = pd.to_datetime(last_month_df['date'], format='%Y-%m-%d')
-last_month_df['amount']=last_month_df['amount'].astype(float)
-last_month_df['exclude_from_totals']=last_month_df['exclude_from_totals'].astype(bool)
-last_month_df['is_income']=last_month_df['is_income'].astype(bool)
+if not full_current_month_df.empty:
+    full_current_month_df.sort_values(by='date', inplace=True) # ensure correct order for cumsum
+    full_current_month_df['cumulative'] = full_current_month_df['amount'].cumsum()
+    full_current_month_df['day'] = full_current_month_df['date'].dt.day
 
-last_month_df = last_month_df[(last_month_df["exclude_from_totals"] == False) & (last_month_df['is_income']== False)]
 
-# Calculate cumulative amounts at the end of each day
-last_month_df['cumulative'] = last_month_df['amount'].cumsum()
-current_month_df['cumulative'] = current_month_df['amount'].cumsum()
+# Calculate cumulative amounts at the end of each day for the primary DFs
+# Ensure dataframes are not empty before attempting cumsum
+if not last_month_df.empty:
+    last_month_df.sort_values(by='date', inplace=True) # ensure correct order for cumsum
+    last_month_df['cumulative'] = last_month_df['amount'].cumsum()
+else:
+    last_month_df['cumulative'] = 0 # Or handle as per requirements for empty df
+
+if not current_month_df.empty:
+    current_month_df.sort_values(by='date', inplace=True) # ensure correct order for cumsum
+    current_month_df['cumulative'] = current_month_df['amount'].cumsum()
+else:
+    current_month_df['cumulative'] = 0 # Or handle as per requirements
 
 # Create a new column for the day of the month
-last_month_df['day'] = last_month_df['date'].dt.day
-current_month_df['day'] = current_month_df['date'].dt.day
+if not last_month_df.empty:
+    # 'day' column already added in get_transactions_df if we decide to move it there
+    # For now, adding it here after cumsum if it wasn't added before.
+    # However, 'date' is needed for sort_values, so 'day' should be added after sorting and cumsum.
+    last_month_df['day'] = last_month_df['date'].dt.day
+else:
+    last_month_df['day'] = None # Or handle as per requirements
+
+if not current_month_df.empty:
+    current_month_df['day'] = current_month_df['date'].dt.day
+else:
+    current_month_df['day'] = None # Or handle as per requirements
+
 
 # Find the nearest available day in the last month
 def find_nearest_available_day(df, target_day):
-    # Find the nearest available day or fallback to the previous day
-    available_days = df['day'].unique()
-    nearest_day = min(available_days, key=lambda x: abs(x - target_day))
+    # Find the nearest available day or fallback to the previous day.
+    # Ensure the DataFrame is not empty and has 'day' column.
+    if df.empty or 'day' not in df.columns or df['day'].isnull().all():
+        return None # Or a default value like 1, or raise an error
+    available_days = df['day'].dropna().unique()
+    if not available_days.size:
+        return None # No available days
+    nearest_day = min(available_days, key=lambda x: abs(x - target_day)) # Ensure available_days is not empty
     return nearest_day
 
-# Find the proportionate cumulative spending for the last month at the same point in time
-equivalent_days_in_previous_month = math.ceil((today.day / today.days_in_month) * start_of_previous_month.days_in_month)
+# This calculation determines a comparable day in the previous month,
+# scaled by the proportion of the current month that has passed.
+equivalent_days_in_previous_month = math.ceil((input_date.day / input_date.days_in_month) * start_of_previous_month.days_in_month)
 
 # Ensure equivalent_days_in_previous_month does not exceed the number of days in the previous month
 last_month_days = start_of_previous_month.days_in_month
 if equivalent_days_in_previous_month > last_month_days:
     equivalent_days_in_previous_month = last_month_days
 
-# Find the nearest available day in the last month that had a payment
-nearest_day_last_month = find_nearest_available_day(last_month_df, equivalent_days_in_previous_month)
+# Default value for cumulative spending last month if no data is available
+cumulative_amount_on_equivalent_day_last_month_val = 0.0
 
-# Find the cumulative amount on the equivalent or nearest available day in the last month
-cumulative_amount_on_equivalent_day_last_month = last_month_df.loc[last_month_df['day'] == nearest_day_last_month, 'cumulative'].tail(1)
+if not last_month_df.empty:
+    # Find the nearest available day in the last month that had a payment
+    nearest_day_last_month = find_nearest_available_day(last_month_df, equivalent_days_in_previous_month)
 
-# Handle the case where there are multiple entries for the same day
-if not cumulative_amount_on_equivalent_day_last_month.empty:
-    # Take the latest cumulative amount
-    cumulative_amount_on_equivalent_day_last_month = cumulative_amount_on_equivalent_day_last_month.tail(1)
+    if nearest_day_last_month is not None:
+        # Find the cumulative amount on the equivalent or nearest available day in the last month
+        cumulative_amount_series = last_month_df.loc[last_month_df['day'] == nearest_day_last_month, 'cumulative']
+
+        if not cumulative_amount_series.empty:
+            # Take the latest cumulative amount for that day
+            cumulative_amount_on_equivalent_day_last_month_val = cumulative_amount_series.iloc[-1]
+        else:
+            # Fallback if specific day had no transactions (e.g. if find_nearest_available_day logic changes)
+            # This part might need adjustment based on how find_nearest_available_day handles no data for target.
+            # For now, assumes find_nearest_available_day returns a day that *has* data.
+            # If not, we might need to iterate backwards from nearest_day_last_month.
+            pass # Handled by initialization
+    # else: No suitable day found in last_month_df, use default 0.0
 else:
-    # Fallback to the previous day
-    previous_day = nearest_day_last_month - 1
-    cumulative_amount_on_equivalent_day_last_month = last_month_df.loc[last_month_df['day'] == previous_day, 'cumulative']
+    # last_month_df is empty, so no transactions last month.
+    # cumulative_amount_on_equivalent_day_last_month_val remains 0.0
+    pass
 
-# Handle the case where the equivalent day is not present
-if cumulative_amount_on_equivalent_day_last_month.empty:
-    # Provide a default value (you can customize based on your requirements)
-    cumulative_amount_on_equivalent_day_last_month = pd.Series([0])
-
-this_month_total = current_month_df['cumulative'].max()
+this_month_total = current_month_df['cumulative'].max() if not current_month_df.empty else 0
 this_month_total = round(this_month_total, 2)
-diff = this_month_total-cumulative_amount_on_equivalent_day_last_month.values[0]
+diff = this_month_total - cumulative_amount_on_equivalent_day_last_month_val
 diff = round(diff, 2)
-s = "NaN"
+
+comparison_summary_text = "NaN"
 if (diff > 0):
-    s = f"Spending this month: ${this_month_total}\n${abs(diff)} more than last month"
+    comparison_summary_text = f"Spending this month: ${this_month_total}\n${abs(diff)} more than last month"
 elif (diff < 0):
-    s = f"Spending this month: ${this_month_total}\n${abs(diff)} less than last month"
+    comparison_summary_text = f"Spending this month: ${this_month_total}\n${abs(diff)} less than last month"
 else:
-    s = f"Spending this month: ${this_month_total}\nYou've spent the same as you did last month"
-print(s)
+    comparison_summary_text = f"Spending this month: ${this_month_total}\nYou've spent the same as you did last month"
+print(comparison_summary_text)
+
 # Plotting
 fig, ax = plt.subplots(figsize=(10, 6))
 
-# add the overlay to explain the diff between this month and same time last month
-fig.text(0.02, 0.78, s, transform=plt.gca().transAxes, fontsize=12, bbox=dict(facecolor='white', alpha=0.8))
+# Add the overlay to explain the diff between this month and same time last month
+fig.text(0.02, 0.78, comparison_summary_text, transform=plt.gca().transAxes, fontsize=12, bbox=dict(facecolor='white', alpha=0.8))
+
+# Plot the cumulative spending for last month, if data exists
+if not last_month_df.empty and 'day' in last_month_df.columns and 'cumulative' in last_month_df.columns:
+    ax.plot(last_month_df['day'], last_month_df['cumulative'], marker='o', label='Last Month', linestyle='--', color='blue')
+
+# Plot the cumulative spending for current month, if data exists
+if not current_month_df.empty and 'day' in current_month_df.columns and 'cumulative' in current_month_df.columns:
+    # Plot actual spending up to input_date (solid line)
+    # current_month_df is already filtered up to input_date + 1 day by get_transactions_df,
+    # then its 'day' and 'cumulative' are calculated.
+    ax.plot(current_month_df['day'], current_month_df['cumulative'], marker='o', label='Current Month Spending', linestyle='-', color='green')
+
+# Plot projected spending for the rest of the month (faded line)
+if not full_current_month_df.empty and 'day' in full_current_month_df.columns and 'cumulative' in full_current_month_df.columns:
+    # Filter data from input_date to the end of the month for the projected line
+    projected_line_df = full_current_month_df[full_current_month_df['date'] >= input_date.replace(hour=0, minute=0, second=0, microsecond=0)]
+    if not projected_line_df.empty:
+        # To make the line connect:
+        # The cumulative sum in full_current_month_df at input_date should naturally align with current_month_df's last point
+        # if current_month_df is a subset of full_current_month_df up to input_date.
+        # Let's ensure the first point of projected_line_df matches the last point of current_month_df if current_month_df is not empty.
+
+        plot_df_for_projection = projected_line_df
+
+        # If current_month_df has data, ensure the projected line starts from its last point
+        if not current_month_df.empty and not current_month_df[current_month_df['date'].dt.date == input_date.date()].empty:
+            last_actual_day_data = current_month_df[current_month_df['date'].dt.date == input_date.date()].iloc[-1]
+
+            # If input_date is not the first day of the month, and we have data for it in full_current_month_df
+            if not projected_line_df[projected_line_df['day'] == input_date.day].empty:
+                 # Update the cumulative value of the first point of the projected line to match the actual spending
+                 projected_line_df.loc[projected_line_df['day'] == input_date.day, 'cumulative'] = last_actual_day_data['cumulative']
+            else: # input_date might not have transactions in full_current_month_df after input_date (e.g. if input_date is last transaction day)
+                  # Or, if it's the first day and no prior transactions, this point is fine.
+                  # We need to add this point to projected_line_df to start the line from there.
+                  # Create a new DataFrame for this single point to avoid SettingWithCopyWarning
+                point_to_add = pd.DataFrame([{
+                    'date': last_actual_day_data['date'],
+                    'day': last_actual_day_data['day'],
+                    'cumulative': last_actual_day_data['cumulative'],
+                    # Add other necessary columns if they are used by plotting, with appropriate values
+                    'amount': 0, # Placeholder, not used for plotting cumulative
+                    'exclude_from_totals': False,
+                    'is_income': False
+                }])
+                plot_df_for_projection = pd.concat([point_to_add, projected_line_df], ignore_index=True).sort_values(by='day').drop_duplicates(subset=['day'], keep='first')
 
 
-# Plot the cumulative spending for last month
-ax.plot(last_month_df['day'], last_month_df['cumulative'], marker='o', label='Last Month', linestyle='--', color='blue')
-
-# Plot the cumulative spending for current month
-ax.plot(current_month_df['day'], current_month_df['cumulative'], marker='o', label='Current Month', linestyle='-', color='green')
+        ax.plot(plot_df_for_projection['day'], plot_df_for_projection['cumulative'], marker='.', label='Projected Spending (Full Month)', linestyle=':', color='darkgreen', alpha=0.7)
 
 plt.xlabel('Day of the Month')
 plt.ylabel('Cumulative Amount Spent')
@@ -150,7 +286,7 @@ plt.legend()
 plt.tight_layout()
 
 # Save the plot as a PNG file
-plt.savefig(f"{today.strftime('%Y-%m-%d')}-cumulative_spending_comparison.png")
+plt.savefig(f"{input_date.strftime('%Y-%m-%d')}-cumulative_spending_comparison.png")
 
 # Close the plot
 plt.close()

--- a/test_comparison.py
+++ b/test_comparison.py
@@ -1,0 +1,48 @@
+import unittest
+import pandas as pd
+from comparison import calculate_date_boundaries
+
+class TestDateCalculations(unittest.TestCase):
+
+    def test_mid_month_date(self):
+        input_dt = pd.Timestamp("2023-03-15")
+        sotm, eopm, sopm = calculate_date_boundaries(input_dt)
+        self.assertEqual(sotm, pd.Timestamp("2023-03-01"))
+        self.assertEqual(eopm, pd.Timestamp("2023-02-28"))
+        self.assertEqual(sopm, pd.Timestamp("2023-02-01"))
+
+    def test_start_of_month(self):
+        input_dt = pd.Timestamp("2023-03-01")
+        sotm, eopm, sopm = calculate_date_boundaries(input_dt)
+        self.assertEqual(sotm, pd.Timestamp("2023-03-01"))
+        self.assertEqual(eopm, pd.Timestamp("2023-02-28"))
+        self.assertEqual(sopm, pd.Timestamp("2023-02-01"))
+
+    def test_end_of_month(self):
+        input_dt = pd.Timestamp("2023-03-31")
+        sotm, eopm, sopm = calculate_date_boundaries(input_dt)
+        self.assertEqual(sotm, pd.Timestamp("2023-03-01"))
+        self.assertEqual(eopm, pd.Timestamp("2023-02-28"))
+        self.assertEqual(sopm, pd.Timestamp("2023-02-01"))
+
+    def test_january_date_previous_year(self):
+        input_dt = pd.Timestamp("2023-01-15")
+        sotm, eopm, sopm = calculate_date_boundaries(input_dt)
+        self.assertEqual(sotm, pd.Timestamp("2023-01-01"))
+        self.assertEqual(eopm, pd.Timestamp("2022-12-31"))
+        self.assertEqual(sopm, pd.Timestamp("2022-12-01"))
+
+    def test_march_date_non_leap_february(self):
+        # Test with a date where previous month is February in a non-leap year (2023)
+        input_dt = pd.Timestamp("2023-03-15")
+        _, eopm, _ = calculate_date_boundaries(input_dt)
+        self.assertEqual(eopm, pd.Timestamp("2023-02-28"))
+
+    def test_march_date_leap_february(self):
+        # Test with a date where previous month is February in a leap year (2024)
+        input_dt = pd.Timestamp("2024-03-15")
+        _, eopm, _ = calculate_date_boundaries(input_dt)
+        self.assertEqual(eopm, pd.Timestamp("2024-02-29"))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces several enhancements to the spending comparison script:

1.  **Optional Date Argument**: The script now accepts an optional `--date` (or `-d`) command-line argument in YYYY-MM-DD format. If you provide it, the comparison is performed for the specified date and the equivalent period in the preceding month. If omitted, it defaults to the current date.

2.  **Refined Date Calculations**: Date calculations have been updated to accurately determine the current and previous month's boundaries based on the input date. Core date boundary logic has been extracted into a `calculate_date_boundaries` function.

3.  **Code Refactoring**: The script has been refactored for clarity and maintainability:
    *   A `get_transactions_df` function now handles API fetching and common data processing, reducing code duplication.
    *   Variable names have been improved (e.g., `s` to `comparison_summary_text`).
    *   Added more robust error handling for empty DataFrames and API responses.
    *   Ensured transactions are sorted by date before cumulative sums are calculated.

4.  **Enhanced Plotting**:
    *   The comparison plot now includes a projected spending line (dotted green) for the remainder of the input date's month, providing a forecast. This line does not affect the primary spending comparison figures.
    *   Plot labels have been updated for clarity.

5.  **Updated Documentation**: The `README.md` has been updated to:
    *   Document the new `--date` argument and its usage.
    *   Explain the updated comparison logic based on the input date.
    *   Describe the different lines in the generated plot.

6.  **Unit Tests**: Basic unit tests have been added in `test_comparison.py` to verify the correctness of the `calculate_date_boundaries` function, covering various scenarios including month ends, year transitions, and leap years.